### PR TITLE
Added Portuguese (Brazil) language

### DIFF
--- a/langs/pt-BR.json
+++ b/langs/pt-BR.json
@@ -1,5 +1,5 @@
 {
   "name": "Portuguese (Brazil)",
   "code": "pt-BR",
-  "maintainers": ["WendellAdriel"]
+  "maintainers": ["WendellAdriel", "fjoshuajr", "cezaraugusto", "glaucia86", "jcserracampos", "eduardomoroni", "telmogoncalves"]
 }

--- a/langs/pt-BR.json
+++ b/langs/pt-BR.json
@@ -1,5 +1,5 @@
 {
   "name": "Portuguese (Brazil)",
   "code": "pt-BR",
-  "maintainers": ["WendellAdriel", "fjoshuajr", "cezaraugusto", "glaucia86", "jcserracampos", "eduardomoroni", "telmogoncalves"]
+  "maintainers": ["WendellAdriel", "fjoshuajr", "cezaraugusto", "glaucia86", "jcserracampos", "eduardomoroni", "telmogoncalves", "gmsecrieru", "tibuurcio"]
 }

--- a/langs/pt-BR.json
+++ b/langs/pt-BR.json
@@ -1,0 +1,5 @@
+{
+  "name": "Portuguese (Brazil)",
+  "code": "pt-BR",
+  "maintainers": ["WendellAdriel"]
+}


### PR DESCRIPTION
Initial commit for opening the Portuguese translation. I am not aware of any peers who are willing to contribute right now.

I write some posts in English and in Portuguese and already translated some articles:

- https://github.com/CodeShareEducation/old-articles/blob/master/2016-03-14-duelo-dos-pre-processadores.md

- https://github.com/CodeShareEducation/old-articles/blob/master/2016-03-29-entendendo-o-async-e-o-await-em-javascript.md

- https://github.com/CodeShareEducation/old-articles/blob/master/2016-03-30-como-escalonar-o-laravel-horizontalmente-com-docker.md

These are some examples of posts I already translated. I'm willing to help in the translations to help the developers in Brazil because we still have a lot of devs that don't have good skills with the English language.