### PR TITLE
Fix: Force-push to existing sync branch erases human's work-in-progress

### DIFF
--- a/scripts/sync-translations.js
+++ b/scripts/sync-translations.js
@@ -304,9 +304,19 @@ async function syncContentWithUpstream(languageCode) {
       await exec(`git commit -am "merging all conflicts"`, options);
     }
 
-    // Create a new pull request, listing all conflicting files
-    await exec(`git push --set-upstream --force origin ${syncBranch}`, options);
+    try {
+      await exec(`git push --set-upstream origin ${syncBranch}`, options);
+    } catch (error) {
+      // If push fails, it is likely because the remote has been already
+      // updated by a human contributor.
+      console.log(
+        `Push to origin/${syncBranch} failed (likely due to remote updates by human contributors).\n` +
+        `Error: ${error.message}`
+      );
+      return;
+    }
 
+    // Create a new pull request, listing all conflicting files
     const title = `Sync with ${MAIN_REPOSITORY_NAME} @ ${shortHash}`;
 
     let conflictsText = '';


### PR DESCRIPTION
Currently, the translation sync bot (`scripts/sync-translations.js`) pushes to the `sync-xxxxxxx` branch with the `--force` option:

https://github.com/reactjs/translations.react.dev/blob/76615299336af2930c945611d830567033769f13/scripts/sync-translations.js#L308

However, when translation contributors have already started working on translation updates or conflict resolution on the same `sync-xxxxxxx` branch, a force-push from the script will **overwrite their ongoing work in progress**.

### Problem

1. The translation bot creates a sync branch named `sync-xxxxxxx` based on the most recent commit hash of the upstream (English) `main` branch. It then creates a corresponding sync PR. Currently, this happens every Monday. The sync branch contains conflict markers, and translators are expected to resolve them before merging it into `main`.

2. If there have been no updates to the upstream `main` since the previous Monday, the script generates the same `sync-xxxxxxx` branch and force-pushes it.

3. If contributors have already started translation sync work (e.g., resolving conflicts, adding translations, making updates, requesting reviews, or discussing changes) on that `sync-xxxxxxx` branch, the script's force-push will erase their work.

This problem doesn't surface when the upstream (English) `main` is updated at least once a week (between two Mondays), which is why I didn't notice it until recently.

### What Actually Happened

Currently, the English site's `main` branch has remained at commit `50d6991` for a few weeks.

1. On Jun 9, the bot (correctly) created a new PR with many conflict markers: reactjs/ja.react.dev#840  
2. On Jun 16, I did the syncing work (resolving conflicts and adding translations), pushed to the sync branch, and requested a review from another Japanese maintainer.  
3. On Jun 19, the other maintainer approved my work.  
4. **On Jun 23, the bot force-pushed to the branch, overwriting all my work and restoring all the conflict markers.**  
5. A few hours later, I accidentally merged the PR without noticing the bot's force-push. As a result, many conflict markers were merged into `main`.

### Solution

There is no need to use the `--force` flag. Sync branches are where translators perform substantial manual work. If a branch with the same name already exists and its head hash is different, it indicates that a human translator has modified the sync branch. The bot must not touch it.

@rickhanlonii Please take a look at this