### PR TITLE
Add Uzbek (uz) translation

### DIFF
--- a/langs/langs.json
+++ b/langs/langs.json
@@ -38,6 +38,7 @@
   { "code": "tr", "name": "Türkçe", "enName": "Turkish" },
   { "code": "uk", "name": "Українська", "enName": "Ukrainian" },
   { "code": "ur", "name": "اردو", "enName": "Urdu" },
+  { "code": "uz", "name": "O'zbek", "enName": "Uzbek" },
   { "code": "vi", "name": "Tiếng Việt", "enName": "Vietnamese" },
   { "code": "zh-hans", "name": "简体中文", "enName": "Simplified Chinese" },
   { "code": "zh-hant", "name": "繁體中文", "enName": "Traditional Chinese" }


### PR DESCRIPTION
## Summary

This PR adds Uzbek (`uz`) to the language registry in `langs/langs.json`.

Uzbek has ~40 million native speakers and is the official language of Uzbekistan. It currently lacks representation in most developer tools and documentation.

I am willing to serve as the maintainer for `uz.react.dev` and am committed to driving the translation to completion.

Previous Uzbek translation contributions:
- https://github.com/colinhacks/zod/pull/5599
- https://github.com/npmx-dev/npmx.dev/pull/2491
- https://github.com/open-circle/valibot/pull/1452
- https://github.com/victrme/Bonjourr/pull/812
- https://github.com/anomalyco/opencode/pull/23992